### PR TITLE
Improve first-time use UX and add some error handling where there is no Dialogue Sequence present

### DIFF
--- a/addons/parley/components/sidebar.gd
+++ b/addons/parley/components/sidebar.gd
@@ -16,6 +16,8 @@ var dialogue_ast_filter: String = "": set = _set_dialogue_ast_filter
 @onready var node_list: ItemList = %NodesItemList
 @onready var dialogue_sequences_list: ItemList = %DialogueSequencesList
 @onready var current_dialogue_sequence_label: LineEdit = %CurrentDialogueSequence
+@onready var manage_dialogue_sequence_button: Button = %ManageDialogueSequenceButton
+@onready var no_dialogue_sequence_warning_button: Button = %NoDialogueSequenceWarningButton
 
 
 signal dialogue_ast_selected(dialogue_ast: ParleyDialogueSequenceAst)
@@ -29,6 +31,7 @@ func _ready() -> void:
 	dialogue_asts = []
 	_set_current_dialogue_ast(current_dialogue_ast)
 	current_dialogue_sequence_label.tooltip_text = "Edit the Dialogue Sequence"
+	no_dialogue_sequence_warning_button.tooltip_text = "No Dialogue Sequence opened. Please create or open one via the Parley file menu in the top left-hand side."
 #endregion
 
 
@@ -93,8 +96,12 @@ func _render_current_dialogue_sequence() -> void:
 	if current_dialogue_sequence_label:
 		if current_dialogue_ast and current_dialogue_ast.resource_path:
 			current_dialogue_sequence_label.text = current_dialogue_ast.resource_path.get_file()
+			no_dialogue_sequence_warning_button.hide()
+			manage_dialogue_sequence_button.show()
 		else:
 			current_dialogue_sequence_label.text = "No Dialogue Sequence Selected"
+			no_dialogue_sequence_warning_button.show()
+			manage_dialogue_sequence_button.hide()
 #endregion
 
 

--- a/addons/parley/components/sidebar.tscn
+++ b/addons/parley/components/sidebar.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=5 format=3 uid="uid://bl5g47dhb7hmk"]
+[gd_scene load_steps=6 format=3 uid="uid://bl5g47dhb7hmk"]
 
 [ext_resource type="Script" uid="uid://dbqp7dc5s5e3n" path="res://addons/parley/components/sidebar.gd" id="1_d0u7e"]
 [ext_resource type="Texture2D" uid="uid://cr4knibdm85n1" path="res://addons/parley/assets/Search.svg" id="2_sqyhy"]
 [ext_resource type="Texture2D" uid="uid://c4qx01xbrjp7h" path="res://addons/parley/assets/Edit.svg" id="3_l7xuh"]
+[ext_resource type="Texture2D" uid="uid://drrcpeyo5x1ih" path="res://addons/parley/assets/Warning.svg" id="4_0tc7b"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_l7xuh"]
 content_margin_left = 12.0
@@ -74,8 +75,14 @@ placeholder_text = "No Dialogue Sequence Selected"
 editable = false
 
 [node name="ManageDialogueSequenceButton" type="Button" parent="VSplitContainer/DialogueSequenceContainer/VBoxContainer/ManageDialogueSequenceContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 icon = ExtResource("3_l7xuh")
+
+[node name="NoDialogueSequenceWarningButton" type="Button" parent="VSplitContainer/DialogueSequenceContainer/VBoxContainer/ManageDialogueSequenceContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+icon = ExtResource("4_0tc7b")
 
 [node name="NodeList" type="VBoxContainer" parent="VSplitContainer/DialogueSequenceContainer/VBoxContainer"]
 layout_mode = 2

--- a/addons/parley/main_panel.gd
+++ b/addons/parley/main_panel.gd
@@ -292,27 +292,36 @@ func _on_new_dialogue_sequence_modal_dialogue_ast_created(new_dialogue_ast: Parl
 
 
 func _on_insert_id_pressed(type: ParleyDialogueSequenceAst.Type) -> void:
+	if not dialogue_ast:
+		push_warning(ParleyUtils.log.warn_msg("Unable to add Node of type %s to the Dialogue Sequence. Dialogue Sequence is not currently loaded into Parley. Please open one via the file menu in the top left-hand side." % ParleyDialogueSequenceAst.get_type_name(type)))
+		return
 	var ast_node: Variant = dialogue_ast.add_new_node(type, (graph_view.scroll_offset + graph_view.size * 0.5) / graph_view.zoom)
 	if ast_node:
 		await refresh()
 
 
 func _on_save_pressed() -> void:
-	_save_dialogue()
+	var result: int = _save_dialogue()
+	if result != OK:
+		return
 	# This is needed to reset the Graph and ensure
 	# that no weirdness is going to happen. For example
 	# move the group nodes after a save when refresh isn't present
 	await refresh()
 
 
-func _save_dialogue() -> void:
+func _save_dialogue() -> int:
+	if not dialogue_ast or not dialogue_ast.resource_path:
+		push_error(ParleyUtils.log.error_msg("Unable to save Dialogue Sequence. Dialogue Sequence does not exist in the file system, please create one using the file menu in the top left-hand side"))
+		return ERR_DOES_NOT_EXIST
 	var ok: int = ResourceSaver.save(dialogue_ast)
 	if ok != OK:
 		push_warning(ParleyUtils.log.warn_msg("Error saving the Dialogue AST: %d" % [ok]))
-		return
+		return ok
 	# This is needed to correctly reload upon file saves
 	if Engine.is_editor_hint():
 		EditorInterface.get_resource_filesystem().reimport_files([dialogue_ast.resource_path])
+	return OK
 
 func _on_arrange_nodes_button_pressed() -> void:
 	selected_node_id = null
@@ -325,13 +334,19 @@ func _on_refresh_button_pressed() -> void:
 
 func _on_test_dialogue_from_start_button_pressed() -> void:
 	# TODO: dialogue is technically async so we should ideally wait here
-	_save_dialogue()
+	var result: int = _save_dialogue()
+	if result != OK:
+		push_error("Error saving Dialogue Sequence: %s. Unable to start Dialogue Sequence testing from start..." % error_string(result))
+		return
 	if parley_manager:
 		parley_manager.run_test_dialogue_from_start(dialogue_ast)
 
 func _on_test_dialogue_from_selected_button_pressed() -> void:
 	# TODO: dialogue is technically async so we should ideally wait here
-	_save_dialogue()
+	var result: int = _save_dialogue()
+	if result != OK:
+		push_error("Error saving Dialogue Sequence: %s. Unable to start Dialogue Sequence testing from Node %s..." % [error_string(result), selected_node_id])
+		return
 	if parley_manager:
 		parley_manager.run_test_dialogue_from_selected(dialogue_ast, selected_node_id)
 #endregion
@@ -620,7 +635,10 @@ func _on_sidebar_edit_dialogue_ast_pressed(selected_dialogue_ast_for_edit: Parle
 
 
 func _on_edit_dialogue_sequence_modal_dialogue_ast_edited(_dialogue_ast: ParleyDialogueSequenceAst) -> void:
-	_save_dialogue()
+	var result: int = _save_dialogue()
+	if result != OK:
+		push_error("Error saving Dialogue Sequence: %s." % error_string(result))
+		return
 	# This is needed to reset the Graph and ensure
 	# that no weirdness is going to happen. For example
 	# move the group nodes after a save when refresh isn't present

--- a/addons/parley/parley_runtime.gd
+++ b/addons/parley/parley_runtime.gd
@@ -27,7 +27,7 @@ func run_dialogue(ctx: Context, dialogue_sequence_ast: DialogueSequenceAst, star
 	var current_scene: Node = _get_current_scene()
 	var dialogue_balloon_path: String = Settings.get_setting(Constants.DIALOGUE_BALLOON_PATH)
 	if not ResourceLoader.exists(dialogue_balloon_path):
-		print_rich(Utils.log.info_msg("Dialogue balloon does not exist at: %s. Stopping..."))
+		print_rich(Utils.log.info_msg("Dialogue balloon does not exist at: %s. Stopping..." % dialogue_balloon_path))
 		return
 	var dialogue_balloon_scene: PackedScene = load(dialogue_balloon_path)
 	var balloon: Node = dialogue_balloon_scene.instantiate()

--- a/docs/latest/getting-started/installation.md
+++ b/docs/latest/getting-started/installation.md
@@ -21,6 +21,11 @@ Editor.
 5. Complete the first time installation by following the
    [first-time installation instructions](#first-time-installation) below.
 
+> [tip]: If you experience compilation errors after downloading Parley, an easy
+> way of rectifying this is to restart your Godot project. If the problem
+> persists however, please raise an issue
+> [here](https://github.com/bisterix-studio/parley/issue).
+
 ### Option 2: Download and install
 
 1. Download the compressed zip file from the
@@ -31,6 +36,11 @@ Editor.
    `addons` directory in your project.
 3. Complete the first-time installation by following the
    [first-time installation instructions](#first-time-installation) below.
+
+> [tip]: If you experience compilation errors after extracting the Parley zip
+> file, an easy way of rectifying this is to restart your Godot project. If the
+> problem persists however, please raise an issue
+> [here](https://github.com/bisterix-studio/parley/issue).
 
 ### First-time installation
 


### PR DESCRIPTION
Closes: #21 

## Changes

- Warning button that appears when there is no Dialogue Sequence
- Better errors for when there is Dialogue Sequence available

## Screenshots

Warning button for when there is no Dialogue Sequence:

<img width="204" height="42" alt="Screenshot 2025-07-17 at 20 35 46" src="https://github.com/user-attachments/assets/06639b57-3ac5-4b9a-a76d-e1d80ae40e6e" />

Warning button tooltip:
<img width="754" height="80" alt="Screenshot 2025-07-17 at 20 35 52" src="https://github.com/user-attachments/assets/4e166e2d-f105-4656-9ba9-6a42125f0bc4" />

Better errors in the Godot output log for common issues:

<img width="1025" height="39" alt="Screenshot 2025-07-17 at 20 36 03" src="https://github.com/user-attachments/assets/acd64070-6e30-4719-9c93-38316cc419d0" />
<img width="1024" height="33" alt="Screenshot 2025-07-17 at 20 36 12" src="https://github.com/user-attachments/assets/bcc0acbc-b426-4cdc-9c5c-b475607f02d0" />
<img width="1002" height="65" alt="Screenshot 2025-07-17 at 20 36 26" src="https://github.com/user-attachments/assets/f5a273a7-6035-4ade-9648-27a6e778d821" />
<img width="1004" height="65" alt="Screenshot 2025-07-17 at 20 36 34" src="https://github.com/user-attachments/assets/44cc23fb-367b-415d-a91a-834763ec42b6" />
