### PR TITLE
Fix incorrectly freed context

### DIFF
--- a/addons/parley/components/default_balloon.gd
+++ b/addons/parley/components/default_balloon.gd
@@ -25,14 +25,6 @@ var previous_node_ast: ParleyNodeAst = null
 var current_node_asts: Array[ParleyNodeAst]: set = _set_current_node_asts
 
 
-#region LIFECYCLE
-func _exit_tree() -> void:
-	# Ensure the ctx is fully cleaned up
-	if ctx and not ctx.is_queued_for_deletion():
-		ctx.free()
-#endregion
-
-
 #region PROCESSING
 ## Start some dialogue
 func start(p_ctx: ParleyContext, p_dialogue_sequence_ast: ParleyDialogueSequenceAst, p_start_node: ParleyNodeAst = null) -> void:

--- a/dialogue_sequences/custom_balloon/custom_balloon.gd
+++ b/dialogue_sequences/custom_balloon/custom_balloon.gd
@@ -25,14 +25,6 @@ var previous_node_ast: ParleyNodeAst = null
 var current_node_asts: Array[ParleyNodeAst]: set = _set_current_node_asts
 
 
-#region LIFECYCLE
-func _exit_tree() -> void:
-	# Ensure the ctx is fully cleaned up
-	if ctx and not ctx.is_queued_for_deletion():
-		ctx.free()
-#endregion
-
-
 #region PROCESSING
 ## Start some dialogue
 func start(p_ctx: ParleyContext, p_dialogue_sequence_ast: ParleyDialogueSequenceAst, p_start_node: ParleyNodeAst = null) -> void:


### PR DESCRIPTION
Closes #51 

Stops auto-freeing context with the balloons, this should be done outside of these

## Testing

 - Basic smoke testing looks good